### PR TITLE
#18 fix bag for base

### DIFF
--- a/app/models/base.go
+++ b/app/models/base.go
@@ -29,7 +29,7 @@ func init() {
 	url := os.Getenv("DATABASE_URL")
 	connection, _ := pq.ParseURL(url)
 	connection += "sslmode=require"
-	Db, err := sql.Open(config.Config.SQLDriver, connection)
+	Db, err = sql.Open(config.Config.SQLDriver, connection)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
base.goにバグが生じた．
原因としては、変数を暗黙的に宣言していたためだと考えられる．
`Db`は元々関数外で宣言していたため、更新をする必要があった．
`Db, err := ...` -> `Db, err = ...`
